### PR TITLE
refactor: update regex to allow for email addresses

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -12,7 +12,7 @@ import (
 )
 
 // regex to capture all variations of filter string
-var qre = regexp.MustCompile(`(\w+)(\=\=|\!\=|\=\=\=|\!\=\=|\~|\!\~|>|<|>\=|\=<|\$\=\=|\$\>|\$\>\=|\$\<|\$\<\=|\@\=\=|\@\!\=|\@\!\~|\@\=\~)([\w-]+)(\,|\;)?`)
+var qre = regexp.MustCompile(`(\w+)(\=\=|\!\=|\=\=\=|\!\=\=|\~|\!\~|>|<|>\=|\=<|\$\=\=|\$\>|\$\>\=|\$\<|\$\<\=|\@\=\=|\@\!\=|\@\!\~|\@\=\~)([\w-@.]+)(\,|\;)?`)
 
 // regex to capture all variations of date string
 // https://play.golang.org/p/NzeBmlQh13v


### PR DESCRIPTION
needed to update regex to accept email addresses

without this fix, `depositor===george@costanza.com` was getting cut off, a la `depositor===george`